### PR TITLE
Reorder oned configurator scripts to avoid 'Use before init' errors

### DIFF
--- a/helm/opennebula/scripts/configurator.oned
+++ b/helm/opennebula/scripts/configurator.oned
@@ -9,16 +9,9 @@ configure_cluster
   {{- printf " template=%s" (include "opennebula.config" .template | squote) }}
 {{- end }}
 
-{{- range .Values.configurator.images }}
-configure_image
+{{- range .Values.configurator.groups }}
+configure_group
   {{- printf " name=%s" (.name | squote) }}
-  {{- printf " user=%s" (.user | squote) }}
-  {{- printf " group=%s" (.group | squote) }}
-  {{- printf " chmod=%s" (.chmod | squote) }}
-  {{- printf " path=%s" (.path | squote) }}
-  {{- printf " size=%s" (.size | squote) }}
-  {{- printf " type=%s" (.type | squote) }}
-  {{- printf " datastore=%s" (.datastore | squote) }}
   {{- printf " template=%s" (include "opennebula.config" .template | squote) }}
 {{- end }}
 
@@ -32,21 +25,22 @@ configure_datastore
   {{- printf " template=%s" (include "opennebula.config" .template | squote) }}
 {{- end }}
 
-{{- range .Values.configurator.groups }}
-configure_group
-  {{- printf " name=%s" (.name | squote) }}
-  {{- printf " template=%s" (include "opennebula.config" .template | squote) }}
-{{- end }}
-
-{{- range .Values.configurator.hooks }}
-configure_hook
-  {{- printf " name=%s" (.name | squote) }}
-  {{- printf " template=%s" (include "opennebula.config" .template | squote) }}
-{{- end }}
-
 {{- range .Values.configurator.marketplaces }}
 configure_marketplace
   {{- printf " name=%s" (.name | squote) }}
+  {{- printf " template=%s" (include "opennebula.config" .template | squote) }}
+{{- end }}
+
+{{- range .Values.configurator.images }}
+configure_image
+  {{- printf " name=%s" (.name | squote) }}
+  {{- printf " user=%s" (.user | squote) }}
+  {{- printf " group=%s" (.group | squote) }}
+  {{- printf " chmod=%s" (.chmod | squote) }}
+  {{- printf " path=%s" (.path | squote) }}
+  {{- printf " size=%s" (.size | squote) }}
+  {{- printf " type=%s" (.type | squote) }}
+  {{- printf " datastore=%s" (.datastore | squote) }}
   {{- printf " template=%s" (include "opennebula.config" .template | squote) }}
 {{- end }}
 
@@ -88,6 +82,12 @@ configure_vntemplate
 {{- range $vnet := .Values.configurator.acl }}
 configure_acl
   {{- printf " acl=%s" (.acl | squote) }}
+{{- end }}
+
+{{- range .Values.configurator.hooks }}
+configure_hook
+  {{- printf " name=%s" (.name | squote) }}
+  {{- printf " template=%s" (include "opennebula.config" .template | squote) }}
 {{- end }}
 
 finish

--- a/helm/opennebula/scripts/functions.sh
+++ b/helm/opennebula/scripts/functions.sh
@@ -247,7 +247,7 @@ configure_group() {
 configure_hook() {
   (
     set -e
-    echo "[datastore] $@"
+    echo "[hook] $@"
     local "$@"
     if [ -z "$name" ]; then
       echo 'name is required'


### PR DESCRIPTION
Oned configurator attempts to use resources before they get initialized (e.g.: create image before datastore gets configured; assign image to group before group gets created;..), this should fix that.

I also snuck in a small correction in `functions.sh`